### PR TITLE
Add Google Analytics tracking + change Clarity project id

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -24,7 +24,7 @@ export const metadata: Metadata = {
     "Transformando espaços através da neuroarquitetura - criando ambientes que elevam o bem-estar, a produtividade e as emoções através de soluções arquitetônicas baseadas em evidências.",
 };
 
-const shouldLoadClarity =
+const shouldLoadTracking =
   process.env.VERCEL_ENV === "preview" ||
   process.env.VERCEL_ENV === "production";
 
@@ -35,16 +35,34 @@ export default function RootLayout({
 }) {
   return (
     <html lang="pt-BR">
-      {shouldLoadClarity && (
-        <Script id="clarity-script" strategy="afterInteractive">
-          {`
+      {shouldLoadTracking && (
+        <>
+          <Script id="clarity-script" strategy="afterInteractive">
+            {`
             (function(c,l,a,r,i,t,y){
                 c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
                 t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
                 y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
             })(window, document, "clarity", "script", "${process.env.NEXT_PUBLIC_CLARITY_PROJECT_ID}");
           `}
-        </Script>
+          </Script>
+          <Script
+            strategy="afterInteractive"
+            src={`https://www.googletagmanager.com/gtag/js?id=${process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS_ID}`}
+          />
+          <Script
+            id="gtag-init"
+            strategy="afterInteractive"
+            dangerouslySetInnerHTML={{
+              __html: `
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+            gtag('config', '${process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS_ID}');
+          `,
+            }}
+          />
+        </>
       )}
 
       <body


### PR DESCRIPTION
This MR adds initial Google Analytics tracking and also changes the Clarity project id in the .env file to use the one created from Thereza's google account. Google Analytics were also created from her account.

NEXT_PUBLIC variables for Google Analytics was added in vercel config and the one for Clarity was updated with the new id.